### PR TITLE
feat: ticket #19 - implement TanStack Query hooks for todos

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -406,7 +406,7 @@ Build axios client with interceptors and todo API methods with Zod validation.
 ---
 
 ### Ticket #19 (GH #22) - Create TanStack Query hooks
-**Status:** Not Started  
+**Status:** ✅ Completed  
 **GitHub Issue:** [akarthickarun/smart-todo-app#22](https://github.com/akarthickarun/smart-todo-app/issues/22)  
 **Dependencies:** #18  
 **Estimated:** 1.5 days
@@ -415,17 +415,17 @@ Build axios client with interceptors and todo API methods with Zod validation.
 Implement custom hooks for querying and mutating todos with TanStack Query v5.
 
 **Acceptance Criteria:**
-- [ ] Create src/lib/query-client.ts with QueryClient configuration
-- [ ] Configure defaults: retry, refetchOnWindowFocus, staleTime, gcTime
-- [ ] Create src/features/todos/hooks/useTodos.ts (query all todos, optional filter)
-- [ ] Create src/features/todos/hooks/useGetTodoById.ts (query single todo)
-- [ ] Create src/features/todos/hooks/useCreateTodo.ts (mutation)
-- [ ] Create src/features/todos/hooks/useUpdateTodo.ts (mutation)
-- [ ] Create src/features/todos/hooks/useDeleteTodo.ts (mutation)
-- [ ] All hooks use queryKey namespacing: ['todos'], ['todos', id]
-- [ ] Mutations invalidate relevant queries on success
-- [ ] Error handling provides user feedback via toast
-- [ ] Wrap App with QueryClientProvider in main.tsx
+- [x] Create src/lib/query-client.ts with QueryClient configuration
+- [x] Configure defaults: retry, refetchOnWindowFocus, staleTime, gcTime
+- [x] Create src/features/todos/hooks/useTodos.ts (query all todos, optional filter)
+- [x] Create src/features/todos/hooks/useGetTodoById.ts (query single todo)
+- [x] Create src/features/todos/hooks/useCreateTodo.ts (mutation)
+- [x] Create src/features/todos/hooks/useUpdateTodo.ts (mutation)
+- [x] Create src/features/todos/hooks/useDeleteTodo.ts (mutation)
+- [x] All hooks use queryKey namespacing: ['todos'], ['todos', id]
+- [x] Mutations invalidate relevant queries on success
+- [x] Error handling provides user feedback via toast (sonner)
+- [x] Wrap App with QueryClientProvider in main.tsx
 
 ---
 
@@ -638,7 +638,7 @@ Set up VS Code build tasks for both frontend and backend, and implement automate
 | 4. API Layer | #11-12 | ✅ #11-12 Completed |
 | 5. Backend Testing | #13-14 | ✅ #13-14 Completed |
 | 6. Frontend Setup | #15-17 | ✅ #15-17 Completed |
-| 7. Frontend API & State | #18-19 | ✅ #18 Completed, #19 Not Started |
+| 7. Frontend API & State | #18-19 | ✅ #18-19 Completed |
 | 8. Frontend UI | #20-21 | Not Started |
 | 9. Frontend Testing | #22-23 | Not Started |
 | 10. DevOps & CI | #24-25 | Not Started |

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.62.0",
     "react-router-dom": "^7.9.0",
+    "sonner": "^1.7.0",
     "tailwind-merge": "^3.5.0",
     "zod": "^3.25.76",
     "zustand": "^4.5.7"

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,7 +1,13 @@
-import { AppRouter } from './router';
+import { Toaster } from 'sonner'
+import { AppRouter } from './router'
 
 function App() {
-  return <AppRouter />;
+  return (
+    <>
+      <AppRouter />
+      <Toaster position="top-right" richColors />
+    </>
+  )
 }
 
-export default App;
+export default App

--- a/src/frontend/src/features/todos/hooks/index.ts
+++ b/src/frontend/src/features/todos/hooks/index.ts
@@ -1,0 +1,5 @@
+export { useTodos } from './useTodos'
+export { useGetTodoById } from './useGetTodoById'
+export { useCreateTodo } from './useCreateTodo'
+export { useUpdateTodo } from './useUpdateTodo'
+export { useDeleteTodo } from './useDeleteTodo'

--- a/src/frontend/src/features/todos/hooks/useCreateTodo.ts
+++ b/src/frontend/src/features/todos/hooks/useCreateTodo.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { todoApi } from '@/api/todo-api'
+import type { CreateTodoInput } from '@/features/todos/schemas/todoSchemas'
+
+interface UseCreateTodoOptions {
+  onSuccess?: (id: string) => void
+  onError?: (error: Error) => void
+}
+
+/**
+ * Hook to create a new todo
+ * @param options - Optional callbacks for success/error
+ * @returns Mutation result with create function
+ */
+export function useCreateTodo(options?: UseCreateTodoOptions) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: CreateTodoInput) => todoApi.create(data),
+    onSuccess: (id) => {
+      queryClient.invalidateQueries({ queryKey: ['todos'] })
+      toast.success('Todo created successfully')
+      options?.onSuccess?.(id)
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to create todo')
+      options?.onError?.(error)
+    },
+  })
+}

--- a/src/frontend/src/features/todos/hooks/useDeleteTodo.ts
+++ b/src/frontend/src/features/todos/hooks/useDeleteTodo.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { todoApi } from '@/api/todo-api'
+
+interface UseDeleteTodoOptions {
+  onSuccess?: () => void
+  onError?: (error: Error) => void
+}
+
+/**
+ * Hook to delete a todo
+ * @param options - Optional callbacks for success/error
+ * @returns Mutation result with delete function
+ */
+export function useDeleteTodo(options?: UseDeleteTodoOptions) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: string) => todoApi.delete(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: ['todos'] })
+      queryClient.invalidateQueries({ queryKey: ['todos', id] })
+      toast.success('Todo deleted successfully')
+      options?.onSuccess?.()
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to delete todo')
+      options?.onError?.(error)
+    },
+  })
+}

--- a/src/frontend/src/features/todos/hooks/useGetTodoById.ts
+++ b/src/frontend/src/features/todos/hooks/useGetTodoById.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+import { todoApi } from '@/api/todo-api'
+import type { TodoItem } from '@/features/todos/schemas/todoSchemas'
+
+/**
+ * Hook to fetch a single todo by ID
+ * @param id - Todo item ID
+ * @returns Query result with single todo
+ */
+export function useGetTodoById(id: string) {
+  return useQuery<TodoItem>({
+    queryKey: ['todos', id],
+    queryFn: () => todoApi.getById(id),
+  })
+}

--- a/src/frontend/src/features/todos/hooks/useTodos.ts
+++ b/src/frontend/src/features/todos/hooks/useTodos.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+import { todoApi } from '@/api/todo-api'
+import type { TodoItem } from '@/features/todos/schemas/todoSchemas'
+
+/**
+ * Hook to fetch all todos with optional status filter
+ * @param status - Optional status filter (Pending | Completed)
+ * @returns Query result with todos list
+ */
+export function useTodos(status?: string) {
+  return useQuery<TodoItem[]>({
+    queryKey: ['todos', status],
+    queryFn: () => todoApi.getAll(status),
+  })
+}

--- a/src/frontend/src/features/todos/hooks/useTodos.ts
+++ b/src/frontend/src/features/todos/hooks/useTodos.ts
@@ -1,13 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
 import { todoApi } from '@/api/todo-api'
-import type { TodoItem } from '@/features/todos/schemas/todoSchemas'
+import type { TodoItem, TodoStatus } from '@/features/todos/schemas/todoSchemas'
 
 /**
  * Hook to fetch all todos with optional status filter
  * @param status - Optional status filter (Pending | Completed)
  * @returns Query result with todos list
  */
-export function useTodos(status?: string) {
+export function useTodos(status?: TodoStatus) {
   return useQuery<TodoItem[]>({
     queryKey: ['todos', status],
     queryFn: () => todoApi.getAll(status),

--- a/src/frontend/src/features/todos/hooks/useUpdateTodo.ts
+++ b/src/frontend/src/features/todos/hooks/useUpdateTodo.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { todoApi } from '@/api/todo-api'
+import type { UpdateTodoInput } from '@/features/todos/schemas/todoSchemas'
+
+interface UseUpdateTodoOptions {
+  onSuccess?: () => void
+  onError?: (error: Error) => void
+}
+
+interface UpdateTodoData {
+  id: string
+  data: UpdateTodoInput
+}
+
+/**
+ * Hook to update an existing todo
+ * @param options - Optional callbacks for success/error
+ * @returns Mutation result with update function
+ */
+export function useUpdateTodo(options?: UseUpdateTodoOptions) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, data }: UpdateTodoData) => todoApi.update(id, data),
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: ['todos'] })
+      queryClient.invalidateQueries({ queryKey: ['todos', id] })
+      toast.success('Todo updated successfully')
+      options?.onSuccess?.()
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to update todo')
+      options?.onError?.(error)
+    },
+  })
+}

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -1,10 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from './lib/query-client'
 import './styles/globals.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
- Create useTodos hook for fetching todos with optional status filter

- Create useGetTodoById hook for fetching single todo by ID

- Create useCreateTodo mutation hook with toast notifications

- Create useUpdateTodo mutation hook with toast notifications

- Create useDeleteTodo mutation hook with toast notifications

- All hooks use proper queryKey namespacing: ['todos'], ['todos', id]

- Mutations invalidate relevant queries on success

- Add sonner dependency for toast notifications

- Wrap App with QueryClientProvider in main.tsx

- Add Toaster component to App for displaying toasts

Closes #22